### PR TITLE
Add optional `production` flag.

### DIFF
--- a/packages/rxjs-debug/src/lib/debugger.ts
+++ b/packages/rxjs-debug/src/lib/debugger.ts
@@ -40,6 +40,10 @@ let debuggersCount = 0;
  * @param options Configuration options for RxJS-debugger instance.
  */
 export function $D<T>($: Observable<T>, options?: DebuggerOptions): Observable<T> {
+  if (options.production) {
+    return $;
+  }
+
   const d$ = new Observable<T>();
   d$.source = $;
   $ = d$;

--- a/packages/rxjs-debug/src/lib/debugger.ts
+++ b/packages/rxjs-debug/src/lib/debugger.ts
@@ -40,6 +40,10 @@ let debuggersCount = 0;
  * @param options Configuration options for RxJS-debugger instance.
  */
 export function $D<T>($: Observable<T>, options?: DebuggerOptions): Observable<T> {
+  if (options.production) {
+    return $;
+  }
+  
   const d$ = new Observable<T>();
   d$.source = $;
   $ = d$;

--- a/packages/rxjs-debug/src/lib/debugger.ts
+++ b/packages/rxjs-debug/src/lib/debugger.ts
@@ -40,6 +40,8 @@ let debuggersCount = 0;
  * @param options Configuration options for RxJS-debugger instance.
  */
 export function $D<T>($: Observable<T>, options?: DebuggerOptions): Observable<T> {
+  options = options || {};
+
   if (options.production) {
     return $;
   }
@@ -48,7 +50,6 @@ export function $D<T>($: Observable<T>, options?: DebuggerOptions): Observable<T
   d$.source = $;
   $ = d$;
 
-  options = options || {};
   const debuggerId: string = String(options.id ?? ++debuggersCount);
 
   const ogSubscribe = $.subscribe;

--- a/packages/rxjs-debug/src/lib/models.ts
+++ b/packages/rxjs-debug/src/lib/models.ts
@@ -28,4 +28,9 @@ export interface DebuggerOptions {
    * normal terminals will just print the raw styles.
    */
   noStyling?: boolean;
+  /**
+   * If set to `true`, logging will be disabled
+   * e.g.: you might not want to log streams if you are in production environment
+   */
+  production?: boolean;  
 }

--- a/packages/rxjs-debug/src/lib/models.ts
+++ b/packages/rxjs-debug/src/lib/models.ts
@@ -32,5 +32,5 @@ export interface DebuggerOptions {
    * If set to `true`, logging will be disabled
    * e.g.: you might not want to log streams if you are in production environment
    */
-  production?: boolean;  
+  production?: boolean;
 }


### PR DESCRIPTION
So after i went through source code, I did not find anything related to disable logging all together if application was in a production environment, so I decided to give it a quick update, I want to use this library in my application, but I also dont want to wrap things in if/else statements and control which source observable to use in which environment.

I hope i did not miss this feature in already existing version of this library.
